### PR TITLE
Fetch tags as well

### DIFF
--- a/.github/workflows/tests-and-docker-images.yml
+++ b/.github/workflows/tests-and-docker-images.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1.14.1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| License         | Apache 2.0


### What's in this PR?
Fetch tags before building docker image otherwise we won't be able to use the last tag as the version value