### PR TITLE
PodPolicy.annotations applies to pods, not services

### DIFF
--- a/website/docs/6_references/1_cassandra_cluster.md
+++ b/website/docs/6_references/1_cassandra_cluster.md
@@ -100,7 +100,7 @@ spec:
 
 |Field|Type|Description|Required|Default|
 |-----|----|-----------|--------|--------|
-|annotations|map\[string\]string|Annotations specifies the annotations to attach to headless service the CassKop operator creates|No|-|
+|annotations|map\[string\]string|Annotations specifies the annotations to attach to pods the CassKop operator creates|No|-|
 |tolerations|[Toleration](https://godoc.org/k8s.io/api/core/v1#Toleration)|Tolerations specifies the tolerations to attach to the pods the CassKop operator creates|No| - |
 
 ## ServicePolicy


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [N]
| New feature?    | [N]
| API breaks?     | [N]
| Deprecations?   | [N]
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Documentation fix.  PodPolicy "annotations" applies to Pods, not Services.


### Why?
Documentation needs an update.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
