### PR TITLE
#99 issue 99 make casskop compatible with k8s 1.25

### DIFF
--- a/controllers/cassandracluster/cassandracluster_controller.go
+++ b/controllers/cassandracluster/cassandracluster_controller.go
@@ -25,7 +25,7 @@ import (
 
 	api "github.com/cscetbon/casskop/api/v2"
 	appsv1 "k8s.io/api/apps/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +51,7 @@ type CassandraClusterReconciler struct {
 	Scheme *runtime.Scheme
 	Log    logr.Logger
 
-	storedPdb         *policyv1beta1.PodDisruptionBudget
+	storedPdb         *policyv1.PodDisruptionBudget
 	storedStatefulSet *appsv1.StatefulSet
 }
 

--- a/controllers/cassandracluster/decommission_test.go
+++ b/controllers/cassandracluster/decommission_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -27,7 +27,7 @@ func createCassandraClusterWithNoDisruption(t *testing.T, cassandraClusterFileNa
 	*reconcile.Request) {
 	rcc, req := helperCreateCassandraCluster(context.TODO(), t, cassandraClusterFileName)
 
-	pdb := &policyv1beta1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rcc.cc.Name,
 			Namespace: rcc.cc.Namespace,

--- a/controllers/cassandracluster/deploy_cassandra.go
+++ b/controllers/cassandracluster/deploy_cassandra.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	api "github.com/cscetbon/casskop/api/v2"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	"github.com/cscetbon/casskop/pkg/k8s"
 
@@ -79,7 +79,7 @@ func (rcc *CassandraClusterReconciler) ensureCassandraPodDisruptionBudget(ctx co
 	return err
 }
 
-func (rcc *CassandraClusterReconciler) podDisruptionBudgetEnvelope(cc *api.CassandraCluster) *policyv1beta1.PodDisruptionBudget {
+func (rcc *CassandraClusterReconciler) podDisruptionBudgetEnvelope(cc *api.CassandraCluster) *policyv1.PodDisruptionBudget {
 	labels := k8s.LabelsForCassandra(cc)
 	return generatePodDisruptionBudget(cc.Name, cc.Namespace, labels, k8s.AsOwner(cc),
 		intstr.FromInt(int(cc.Spec.MaxPodUnavailable)))

--- a/controllers/cassandracluster/generator.go
+++ b/controllers/cassandracluster/generator.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -506,15 +506,15 @@ func defineJvmMemory(resources v1.ResourceRequirements) JvmMemory {
 }
 
 func generatePodDisruptionBudget(name string, namespace string, labels map[string]string,
-	ownerRefs metav1.OwnerReference, maxUnavailable intstr.IntOrString) *policyv1beta1.PodDisruptionBudget {
-	return &policyv1beta1.PodDisruptionBudget{
+	ownerRefs metav1.OwnerReference, maxUnavailable intstr.IntOrString) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
 			OwnerReferences: []metav1.OwnerReference{ownerRefs},
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,

--- a/controllers/cassandracluster/poddisruptionbudget.go
+++ b/controllers/cassandracluster/poddisruptionbudget.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,9 +26,9 @@ import (
 
 // GetPodDisruptionBudget return the PodDisruptionBudget name from the cluster in the namespace
 func (rcc *CassandraClusterReconciler) GetPodDisruptionBudget(ctx context.Context, namespace,
-	name string) (*policyv1beta1.PodDisruptionBudget, error) {
+	name string) (*policyv1.PodDisruptionBudget, error) {
 
-	pdb := &policyv1beta1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -38,7 +38,7 @@ func (rcc *CassandraClusterReconciler) GetPodDisruptionBudget(ctx context.Contex
 }
 
 // CreatePodDisruptionBudget create a new PodDisruptionBudget pdb
-func (rcc *CassandraClusterReconciler) CreatePodDisruptionBudget(ctx context.Context, pdb *policyv1beta1.PodDisruptionBudget) error {
+func (rcc *CassandraClusterReconciler) CreatePodDisruptionBudget(ctx context.Context, pdb *policyv1.PodDisruptionBudget) error {
 	err := rcc.Client.Create(ctx, pdb)
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
@@ -50,7 +50,7 @@ func (rcc *CassandraClusterReconciler) CreatePodDisruptionBudget(ctx context.Con
 }
 
 // DeletePodDisruptionBudget delete a new PodDisruptionBudget pdb
-func (rcc *CassandraClusterReconciler) DeletePodDisruptionBudget(ctx context.Context, pdb *policyv1beta1.PodDisruptionBudget) error {
+func (rcc *CassandraClusterReconciler) DeletePodDisruptionBudget(ctx context.Context, pdb *policyv1.PodDisruptionBudget) error {
 	err := rcc.Client.Delete(ctx, pdb)
 	if err != nil {
 		return fmt.Errorf("failed to delete cassandra PodDisruptionBudget: %cc", err)
@@ -59,7 +59,7 @@ func (rcc *CassandraClusterReconciler) DeletePodDisruptionBudget(ctx context.Con
 }
 
 // UpdatePodDisruptionBudget updates an existing PodDisruptionBudget pdb
-func (rcc *CassandraClusterReconciler) UpdatePodDisruptionBudget(ctx context.Context, pdb *policyv1beta1.PodDisruptionBudget) error {
+func (rcc *CassandraClusterReconciler) UpdatePodDisruptionBudget(ctx context.Context, pdb *policyv1.PodDisruptionBudget) error {
 	err := rcc.Client.Update(ctx, pdb)
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
@@ -71,7 +71,7 @@ func (rcc *CassandraClusterReconciler) UpdatePodDisruptionBudget(ctx context.Con
 }
 
 // CreateOrUpdatePodDisruptionBudget Create PodDisruptionBudget if not existing, or update it if existing.
-func (rcc *CassandraClusterReconciler) CreateOrUpdatePodDisruptionBudget(ctx context.Context, pdb *policyv1beta1.PodDisruptionBudget) error {
+func (rcc *CassandraClusterReconciler) CreateOrUpdatePodDisruptionBudget(ctx context.Context, pdb *policyv1.PodDisruptionBudget) error {
 	var err error
 	rcc.storedPdb, err = rcc.GetPodDisruptionBudget(ctx, pdb.Namespace, pdb.Name)
 	if err != nil {

--- a/website/docs/5_operations/1_cluster_operations.md
+++ b/website/docs/5_operations/1_cluster_operations.md
@@ -985,7 +985,7 @@ but if there was an ongoing disruption on the current Cassandra cluster, it won'
 Example of a PDB :
 
 ```yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]


| Related tickets | fixes #99 
| License         | Apache 2.0


### What's in this PR?
It removes deprecated api in kubernetes version 1.25

### Why?
Make casskop operator work on kubernetes 1.25


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ X] Implementation tested
