### PR TITLE
Don't exhaust compaction thread pool with cleanup tasks #105

### DIFF
--- a/api/v2/cassandracluster_types.go
+++ b/api/v2/cassandracluster_types.go
@@ -764,6 +764,10 @@ type CassandraClusterSpec struct {
 	// JMX Secret if Set is used to set JMX_USER and JMX_PASSWORD
 	ImageJolokiaSecret v1.LocalObjectReference `json:"imageJolokiaSecret,omitempty"`
 
+	// Number of jobs (threads) for keyspace cleanup command.
+	// 0 = unlimited.
+	KeyspaceCleanupThreads int32 `json:"keyspaceCleanupThreads,omitempty"`
+
 	//Topology to create Cassandra DC and Racks and to target appropriate Kubernetes Nodes
 	Topology Topology `json:"topology,omitempty"`
 

--- a/charts/casskop/crds/db.orange.com_cassandraclusters.yaml
+++ b/charts/casskop/crds/db.orange.com_cassandraclusters.yaml
@@ -1381,6 +1381,10 @@ spec:
                 imagepullpolicy:
                   description: ImagePullPolicy define the pull policy for C* docker image
                   type: string
+                keyspaceCleanupThreads:
+                  description: Number of jobs (threads) for keyspace cleanup command. 0 = unlimited.
+                  type: integer
+                  format: int32
                 livenessFailureThreshold:
                   description: 'LivenessFailureThreshold defines failure threshold for the liveness probe of the main cassandra container : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes'
                   type: integer

--- a/charts/multi-casskop/crds/db.orange.com_cassandraclusters.yaml
+++ b/charts/multi-casskop/crds/db.orange.com_cassandraclusters.yaml
@@ -1381,6 +1381,10 @@ spec:
                 imagepullpolicy:
                   description: ImagePullPolicy define the pull policy for C* docker image
                   type: string
+                keyspaceCleanupThreads:
+                  description: Number of jobs (threads) for keyspace cleanup command. 0 = unlimited.
+                  type: integer
+                  format: int32
                 livenessFailureThreshold:
                   description: 'LivenessFailureThreshold defines failure threshold for the liveness probe of the main cassandra container : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes'
                   type: integer

--- a/config/crd/bases/db.orange.com_cassandraclusters.yaml
+++ b/config/crd/bases/db.orange.com_cassandraclusters.yaml
@@ -1381,6 +1381,10 @@ spec:
                 imagepullpolicy:
                   description: ImagePullPolicy define the pull policy for C* docker image
                   type: string
+                keyspaceCleanupThreads:
+                  description: Number of jobs (threads) for keyspace cleanup command. 0 = unlimited.
+                  type: integer
+                  format: int32
                 livenessFailureThreshold:
                   description: 'LivenessFailureThreshold defines failure threshold for the liveness probe of the main cassandra container : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes'
                   type: integer

--- a/controllers/cassandracluster/node_operations.go
+++ b/controllers/cassandracluster/node_operations.go
@@ -171,24 +171,24 @@ func (jolokiaClient *JolokiaClient) nonLocalKeyspaces() ([]string, error) {
 NodeCleanup triggers a cleanup of all keyspaces on the pod using a jolokia client and returns the index of the last
 keyspace accessed and any error
 */
-func (jolokiaClient *JolokiaClient) NodeCleanup() error {
+func (jolokiaClient *JolokiaClient) NodeCleanup(threads int32) error {
 	keyspaces, err := jolokiaClient.nonLocalKeyspaces()
 	if err != nil {
 		return err
 	}
-	return jolokiaClient.NodeCleanupKeyspaces(keyspaces)
+	return jolokiaClient.NodeCleanupKeyspaces(threads, keyspaces)
 }
 
 /*
 NodeCleanupKeyspaces triggers a cleanup of each keyspaces on the pod using a jolokia client and returns the index of
 the last keyspace accessed and any error
 */
-func (jolokiaClient *JolokiaClient) NodeCleanupKeyspaces(keyspaces []string) error {
+func (jolokiaClient *JolokiaClient) NodeCleanupKeyspaces(threads int32, keyspaces []string) error {
 	for _, keyspace := range keyspaces {
 		logrus.Infof("[%s]: Cleanup of keyspace %s", jolokiaClient.host, keyspace)
 		_, err := checkJolokiaErrors(jolokiaClient.executeOperation("org.apache.cassandra.db:type=StorageService",
-			"forceKeyspaceCleanup(java.lang.String,[Ljava.lang.String;)",
-			[]interface{}{keyspace, []string{}}, ""))
+			"forceKeyspaceCleanup(int,java.lang.String,[Ljava.lang.String;)",
+			[]interface{}{threads, keyspace, []string{}}, ""))
 		if err != nil {
 			logrus.Errorf("Cleanup of keyspace %s failed: %v", keyspace, err.Error())
 			return err

--- a/controllers/cassandracluster/pod_operation.go
+++ b/controllers/cassandracluster/pod_operation.go
@@ -921,7 +921,7 @@ func (rcc *CassandraClusterReconciler) runCleanup(ctx context.Context, hostName 
 		cc.Spec.ImageJolokiaSecret, cc.Namespace)
 
 	if err == nil {
-		err = jolokiaClient.NodeCleanup()
+		err = jolokiaClient.NodeCleanup(cc.Spec.KeyspaceCleanupThreads)
 	}
 	return err
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | [x]
| Related tickets | fixes #105
| License         | Apache 2.0


### What's in this PR?
New field in cluster spec added: keyspaceCleanupThreads
Backward compatibility: if not specified falls to 0 which effectively behave same as previously - unlimited thread pool


### Why?
Makes compaction thread pool configurable to avoid resource exhaustion #105


### Checklist
- [x] Implementation tested
