### PR TITLE
make services headless again #85, #86

### DIFF
--- a/controllers/cassandracluster/generator.go
+++ b/controllers/cassandracluster/generator.go
@@ -95,7 +95,8 @@ func generateCassandraService(cc *api.CassandraCluster, labels map[string]string
 			OwnerReferences: ownerRefs,
 		},
 		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+			Type:      v1.ServiceTypeClusterIP,
+			ClusterIP: v1.ClusterIPNone,
 			Ports: []v1.ServicePort{
 				{
 					Port:     cassandraPort,
@@ -124,7 +125,8 @@ func generateCassandraExporterService(cc *api.CassandraCluster, labels map[strin
 			OwnerReferences: ownerRefs,
 		},
 		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
+			Type:      v1.ServiceTypeClusterIP,
+			ClusterIP: v1.ClusterIPNone,
 			Ports: []v1.ServicePort{
 				{
 					Port:     exporterCassandraJmxPort,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Related tickets | fixes #85, #86
| License         | Apache 2.0


### What's in this PR?
Going back to headless services as it was in 2.1.13 and before


### Why?
Compatibility is broken as services are not headless anymore.

Partially fixed by #86
Setting empty ClusterIP does not result in default value "None" being set by api-server. Therefore we should set "None" explicitly.


### Checklist
- [x] Implementation tested
