### PR TITLE
Add assert timeout for backup/restore test

### DIFF
--- a/test/kuttl/backup-restore/02-assert.yaml
+++ b/test/kuttl/backup-restore/02-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 500
+---
 apiVersion: db.orange.com/v1alpha1
 kind: CassandraBackup
 metadata:


### PR DESCRIPTION
Fixes: #115

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### To Do
Check if helps fix e2e test execution