### PR TITLE
[e2e tests] Fix api version for casskop custom resources

### DIFF
--- a/test/kuttl/backup-restore/00-assert.yaml
+++ b/test/kuttl/backup-restore/00-assert.yaml
@@ -6,7 +6,7 @@ status:
   currentReplicas: 2
   replicas: 2
 ---
-apiVersion: db.orange.com/v1alpha1
+apiVersion: db.orange.com/v2
 kind: CassandraCluster
 metadata:
   name: cassandra-e2e

--- a/test/kuttl/backup-restore/00-createCluster.yaml
+++ b/test/kuttl/backup-restore/00-createCluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: db.orange.com/v1alpha1
+apiVersion: db.orange.com/v2
 kind: CassandraCluster
 metadata:
   name: cassandra-e2e

--- a/test/kuttl/backup-restore/02-assert.yaml
+++ b/test/kuttl/backup-restore/02-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 500
 ---
-apiVersion: db.orange.com/v1alpha1
+apiVersion: db.orange.com/v2
 kind: CassandraBackup
 metadata:
   name: backup-compat-tests

--- a/test/kuttl/backup-restore/02-backup.yaml
+++ b/test/kuttl/backup-restore/02-backup.yaml
@@ -1,4 +1,4 @@
-apiVersion: db.orange.com/v1alpha1
+apiVersion: db.orange.com/v2
 kind: CassandraBackup
 metadata:
   name: backup-compat-tests

--- a/test/kuttl/backup-restore/03-assert.yaml
+++ b/test/kuttl/backup-restore/03-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: db.orange.com/v1alpha1
+apiVersion: db.orange.com/v2
 kind: CassandraRestore
 metadata:
   name: restore-compat-tests

--- a/test/kuttl/backup-restore/03-restore.yaml
+++ b/test/kuttl/backup-restore/03-restore.yaml
@@ -1,4 +1,4 @@
-apiVersion: db.orange.com/v1alpha1
+apiVersion: db.orange.com/v2
 kind: CassandraRestore
 metadata:
   name: restore-compat-tests


### PR DESCRIPTION
Fix api version for CassandraCluster, CassandraBackup and CassandraRestore to db.orange.com/v2.

Fixes: #115

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0
