### PR TITLE
Fix nodetool execution

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        test-name: [operations, sidecars, scaling, multi-dcs, backup-restore]
+        test-name: [operations, sidecars, scaling, multi-dcs, backup-restore, nodetool]
     steps:
       - id: lower-repo
         shell: pwsh

--- a/test/kuttl/nodetool/00-assert.yaml
+++ b/test/kuttl/nodetool/00-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cassandra-e2e-dc1-rack1
+status:
+  currentReplicas: 2
+  replicas: 2
+---
+apiVersion: db.orange.com/v2
+kind: CassandraCluster
+metadata:
+  name: cassandra-e2e
+status:
+  cassandraRackStatus:
+    dc1-rack1:
+      cassandraLastAction:
+        name: Initializing
+        status: Done
+      phase: Running
+  lastClusterAction: Initializing
+  lastClusterActionStatus: Done
+  phase: Running

--- a/test/kuttl/nodetool/00-createCluster.yaml
+++ b/test/kuttl/nodetool/00-createCluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: db.orange.com/v2
+kind: CassandraCluster
+metadata:
+  name: cassandra-e2e
+spec:
+  nodesPerRacks: 2
+  cassandraImage: cassandra:3.11.9
+  autoPilot: true
+  resources:
+    limits:
+      cpu: 300m
+      memory: 512Mi
+  topology:
+    dc:
+      - name: dc1
+        rack:
+          - name: rack1

--- a/test/kuttl/nodetool/01-nodetool-status.yaml
+++ b/test/kuttl/nodetool/01-nodetool-status.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Run nodetool status
+  - script: kubectl exec cassandra-e2e-dc1-rack1-0 -- nodetool status


### PR DESCRIPTION
Set JAVA_TOOL_OPTIONS to -Dcom.sun.jndi.rmiURLParsing=legacy in order to run nodetool without passing address.

Fixes: #142

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0

- [ x] Implementation tested
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog
