### PR TITLE
Bump cassandra-boostrap to fix CVE-2024-2961

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SERVICE_NAME := casskop
 BUILD_FOLDER = .
 MOUNTDIR = $(PWD)
 
-BOOTSTRAP_IMAGE ?= ghcr.io/cscetbon/casskop-bootstrap:0.1.14
+BOOTSTRAP_IMAGE ?= ghcr.io/cscetbon/casskop-bootstrap:0.1.15
 TELEPRESENCE_REGISTRY ?= datawire
 KUBESQUASH_REGISTRY:=
 KUBECONFIG ?= ~/.kube/config

--- a/api/v2/cassandracluster_types.go
+++ b/api/v2/cassandracluster_types.go
@@ -21,7 +21,7 @@ const (
 	DefaultReadinessHealthCheckPeriod   int32 = 10
 
 	defaultCassandraImage     = "cassandra:3.11.10"
-	defaultBootstrapImage     = "ghcr.io/cscetbon/casskop-bootstrap:0.1.14"
+	defaultBootstrapImage     = "ghcr.io/cscetbon/casskop-bootstrap:0.1.15"
 	defaultConfigBuilderImage = "datastax/cass-config-builder:1.0.4"
 
 	DefaultBackRestImage      = "ghcr.io/cscetbon/instaclustr-icarus:1.1.3"

--- a/test/kuttl/backup-restore/00-createCluster.yaml
+++ b/test/kuttl/backup-restore/00-createCluster.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   nodesPerRacks: 2
   cassandraImage: cassandra:3.11.9
-  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.14
+  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.15
   dataCapacity: 256Mi
   hardAntiAffinity: false
   deletePVC: true

--- a/test/kuttl/sidecars/00-assert.yaml
+++ b/test/kuttl/sidecars/00-assert.yaml
@@ -47,7 +47,7 @@ spec:
         - name: config-builder
           image: datastax/cass-config-builder:1.0.3
         - name: bootstrap
-          image: ghcr.io/cscetbon/casskop-bootstrap:0.1.14
+          image: ghcr.io/cscetbon/casskop-bootstrap:0.1.15
       containers:
       - args:
         - tail

--- a/website/docs/2_setup/5_upgrade_v1_to_v2.md
+++ b/website/docs/2_setup/5_upgrade_v1_to_v2.md
@@ -47,7 +47,7 @@ metadata:
 spec:
   nodesPerRacks: 2
   cassandraImage: cassandra:3.11.9
-  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.14
+  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.15
   config:
     cassandra-yaml:
       num_tokens: 256


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


Use update cassandra-bootstrap image  to avoid CVE-2024-2961
Rebuild of casskop image itself is also required to fix the same CVE-2024-2961