### PR TITLE
Fix resolving logLevel variable in casskop chart

### DIFF
--- a/charts/casskop/templates/deployment.yaml
+++ b/charts/casskop/templates/deployment.yaml
@@ -67,4 +67,4 @@ spec:
           - name: OPERATOR_NAME
             value: "casskop"
           - name: LOG_LEVEL
-            value: .Values.logLevel
+            value: {{ .Values.logLevel }}

--- a/charts/multi-casskop/templates/deployment.yaml
+++ b/charts/multi-casskop/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           - name: OPERATOR_NAME
             value: "multi-casskop"
           - name: LOG_LEVEL
-            value: .Values.logLevel
+            value: {{ .Values.logLevel }}
         volumeMounts:
 {{- range .Values.k8s.remote }}
         - mountPath: /var/run/secrets/admiralty.io/serviceaccountimports/{{ . }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
PR fixes the problem with passing value from values.yaml instead of pushing direct string `.Values.logLevel` to environment variable.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
I just found an obvious issue with passing logLevel variable via values.yaml during the update of casskop to latest 2.2.6 release. See the screen:
![Screenshot 2024-10-15 at 21 51 22](https://github.com/user-attachments/assets/7a22105d-4e9a-4b24-a59a-f9af8da36855)
(This is a diff of the changes that I observe during pushing new chart to k8s)


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
- [ ] Append changelog

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here

@AKamyshnikova @cscetbon any chances to merge this change quickly so I'll be able to fix my cluster without patching the chart locally?