### PR TITLE
Update controller-gen to 0.16.5

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -47,7 +47,7 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | INSTAL
 RUN curl -L https://github.com/gotestyourself/gotestsum/releases/download/v0.3.4/gotestsum_0.3.4_linux_amd64.tar.gz | \
   tar -xz -C /usr/local/bin gotestsum
 RUN go install golang.org/x/lint/golint@latest
-RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.0
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
 RUN go install sigs.k8s.io/kustomize/kustomize/v4@latest
 RUN go install github.com/mikefarah/yq/v4@latest
 


### PR DESCRIPTION
There is a bug in CRD generation with 0.16.0 version - it generates

```
-                              default: TCP
+                              allOf:
+                                - default: TCP
+                                - default: TCP
```
incorrect rules for 'protocol' field in port objects.

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0
