### PR TITLE
Fix backup/restore status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SERVICE_NAME := casskop
 BUILD_FOLDER = .
 MOUNTDIR = $(PWD)
 
-BOOTSTRAP_IMAGE ?= ghcr.io/cscetbon/casskop-bootstrap:0.1.19
+BOOTSTRAP_IMAGE ?= ghcr.io/cscetbon/casskop-bootstrap:0.1.21
 TELEPRESENCE_REGISTRY ?= datawire
 KUBESQUASH_REGISTRY:=
 KUBECONFIG ?= ~/.kube/config

--- a/api/v2/cassandrabackup_types.go
+++ b/api/v2/cassandrabackup_types.go
@@ -72,7 +72,6 @@ func (b BackupConditionType) HasFailed() bool {
 
 // CassandraBackup is the Schema for the cassandrabackups API
 // +k8s:openapi-gen=true
-// +kubebuilder:subresource:status
 type CassandraBackup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v2/cassandracluster_types.go
+++ b/api/v2/cassandracluster_types.go
@@ -21,7 +21,7 @@ const (
 	DefaultReadinessHealthCheckPeriod   int32 = 10
 
 	defaultCassandraImage     = "cassandra:3.11.10"
-	defaultBootstrapImage     = "ghcr.io/cscetbon/casskop-bootstrap:0.1.19"
+	defaultBootstrapImage     = "ghcr.io/cscetbon/casskop-bootstrap:0.1.21"
 	defaultConfigBuilderImage = "datastax/cass-config-builder:1.0.4"
 
 	DefaultBackRestImage      = "ghcr.io/cscetbon/instaclustr-icarus:1.1.3"

--- a/api/v2/cassandrarestore_types.go
+++ b/api/v2/cassandrarestore_types.go
@@ -85,7 +85,6 @@ type CassandraRestoreSpec struct {
 // +resourceName=cassandrarestores
 // +kubebuilder:object:root=true
 // CassandraRestore is a Casskop Operator resource that represents the restoration of a backup of a Cassandra cluster
-// +kubebuilder:subresource:status
 type CassandraRestore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/charts/casskop/crds/db.orange.com_cassandrabackups.yaml
+++ b/charts/casskop/crds/db.orange.com_cassandrabackups.yaml
@@ -131,5 +131,3 @@ spec:
                   type: string
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/charts/casskop/crds/db.orange.com_cassandrarestores.yaml
+++ b/charts/casskop/crds/db.orange.com_cassandrarestores.yaml
@@ -139,5 +139,3 @@ spec:
                   type: string
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/charts/multi-casskop/crds/db.orange.com_cassandrabackups.yaml
+++ b/charts/multi-casskop/crds/db.orange.com_cassandrabackups.yaml
@@ -131,5 +131,3 @@ spec:
                   type: string
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/charts/multi-casskop/crds/db.orange.com_cassandrarestores.yaml
+++ b/charts/multi-casskop/crds/db.orange.com_cassandrarestores.yaml
@@ -139,5 +139,3 @@ spec:
                   type: string
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/config/crd/bases/db.orange.com_cassandrabackups.yaml
+++ b/config/crd/bases/db.orange.com_cassandrabackups.yaml
@@ -131,5 +131,3 @@ spec:
                   type: string
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/config/crd/bases/db.orange.com_cassandrarestores.yaml
+++ b/config/crd/bases/db.orange.com_cassandrarestores.yaml
@@ -139,5 +139,3 @@ spec:
                   type: string
       served: true
       storage: true
-      subresources:
-        status: {}

--- a/controllers/cassandracluster/generator_test.go
+++ b/controllers/cassandracluster/generator_test.go
@@ -257,7 +257,7 @@ func TestInitContainerConfiguration(t *testing.T) {
 		},
 	})
 
-	cc.Spec.ServerVersion = "3.11.9"
+	cc.Spec.ServerVersion = "3.11.19"
 
 	initEnvVar = initContainerEnvVar(cc, &cc.Status, cassieResources, dcRackName)
 

--- a/controllers/cassandracluster/testdata/cassandracluster-2DC-dc1-rack1-sts.yaml
+++ b/controllers/cassandracluster/testdata/cassandracluster-2DC-dc1-rack1-sts.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     spec:
       containers:
-        - image: ext-dockerio.artifactory.si.francetelecom.fr/cassandra:3.11.9
+        - image: ext-dockerio.artifactory.si.francetelecom.fr/cassandra:3.11.19
           imagePullPolicy: Always
           name: cassandra
           ports:
@@ -51,7 +51,7 @@ spec:
             - sh
             - -c
             - cp -vr /etc/cassandra/* /bootstrap
-          image: ext-dockerio.artifactory.si.francetelecom.fr/cassandra:3.11.9
+          image: ext-dockerio.artifactory.si.francetelecom.fr/cassandra:3.11.19
           imagePullPolicy: Always
           name: init-config
           resources:

--- a/test/kuttl/backup-restore/00-createCluster.yaml
+++ b/test/kuttl/backup-restore/00-createCluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: cassandra-e2e
 spec:
   nodesPerRacks: 2
-  cassandraImage: cassandra:3.11.9
-  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.19
+  cassandraImage: cassandra:3.11.19
+  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.21
   dataCapacity: 256Mi
   hardAntiAffinity: false
   deletePVC: true

--- a/test/kuttl/multi-dcs/00-createCluster.yaml
+++ b/test/kuttl/multi-dcs/00-createCluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-e2e
 spec:
   nodesPerRacks: 1
-  cassandraImage: cassandra:3.11.9
+  cassandraImage: cassandra:3.11.19
   dataCapacity: "256Mi"
   deletePVC: true
   autoPilot: true

--- a/test/kuttl/nodetool/00-createCluster.yaml
+++ b/test/kuttl/nodetool/00-createCluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-e2e
 spec:
   nodesPerRacks: 2
-  cassandraImage: cassandra:3.11.9
+  cassandraImage: cassandra:3.11.19
   autoPilot: true
   resources:
     limits:

--- a/test/kuttl/operations/00-createCluster.yaml
+++ b/test/kuttl/operations/00-createCluster.yaml
@@ -12,7 +12,7 @@ metadata:
   name: cassandra-e2e
 spec:
   nodesPerRacks: 2
-  cassandraImage: cassandra:3.11.9
+  cassandraImage: cassandra:3.11.19
   configMapName: configmap-v1
   autoPilot: true
   resources:

--- a/test/kuttl/sidecars/00-assert.yaml
+++ b/test/kuttl/sidecars/00-assert.yaml
@@ -43,11 +43,11 @@ spec:
     spec:
       initContainers:
         - name: base-config-builder
-          image: cassandra:3.11.9
+          image: cassandra:3.11.19
         - name: config-builder
           image: datastax/cass-config-builder:1.0.3
         - name: bootstrap
-          image: ghcr.io/cscetbon/casskop-bootstrap:0.1.19
+          image: ghcr.io/cscetbon/casskop-bootstrap:0.1.21
       containers:
       - args:
         - tail

--- a/test/kuttl/sidecars/00-clusterWithTwoSidecars.yaml
+++ b/test/kuttl/sidecars/00-clusterWithTwoSidecars.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-e2e
 spec:
   nodesPerRacks: 1
-  cassandraImage: cassandra:3.11.9
+  cassandraImage: cassandra:3.11.19
   configBuilderImage: datastax/cass-config-builder:1.0.3
   dataCapacity: "256Mi"
   hardAntiAffinity: false

--- a/website/docs/2_setup/5_upgrade_v1_to_v2.md
+++ b/website/docs/2_setup/5_upgrade_v1_to_v2.md
@@ -46,8 +46,8 @@ metadata:
   name: your-object
 spec:
   nodesPerRacks: 2
-  cassandraImage: cassandra:3.11.9
-  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.19
+  cassandraImage: cassandra:3.11.19
+  bootstrapImage: ghcr.io/cscetbon/casskop-bootstrap:0.1.21
   config:
     cassandra-yaml:
       num_tokens: 256


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Revert adding `subresource:status` for CassandraBackup and CassandraRestore types. Patch is used to set status.
