### PR TITLE
Update ci image lib

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -L https://github.com/gotestyourself/gotestsum/releases/download/v0.3.4
 RUN go install golang.org/x/lint/golint@latest
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
 RUN go install sigs.k8s.io/kustomize/kustomize/v4@latest
-RUN go install github.com/mikefarah/yq/v4@latest
+RUN go install github.com/mikefarah/yq/v4@v4.44.6
 
 # Install kubectl cli
 RUN curl -o /usr/local/bin/kubectl -L https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl \


### PR DESCRIPTION
Set github.com/mikefarah/yq to v4.44.6 as
latest already expect go 1.24

Currently ci image build is broken:

`github.com/mikefarah/yq/v4@latest: github.com/mikefarah/yq/v4@v4.45.4 requires go >= 1.24 (running go 1.23.10; GOTOOLCHAIN=local)`

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0

